### PR TITLE
Add options to set C/C++ compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
 
       - run:
           name: Install packages
-          command: pacman --sync --noconfirm gcc git meson ninja vim
+          command: pacman --sync --noconfirm clang gcc git meson ninja vim
 
       - checkout
 
@@ -23,3 +23,4 @@ jobs:
           command: |
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-build-file-error.vader' > /dev/null
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-compile-project.vader' > /dev/null
+            vim -Nu ./test/.vimrc -c 'Vader! test/meson-compiler.vader' > /dev/null

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ vim-mesonist is a Vim plugin to make working with
  * `g:mesonist_meson_builddir` sets the meson build directory to use.
  Defaults to `builddir`.
 
+ * `g:mesonist_c_compiler` sets the C compiler to use. Same as environment
+ variable `CC`.
+
+ * `g:mesonist_cxx_compiler` sets the C++ compiler to use. Same as environment
+ variable `CXX`.
+
 ## Installation
 
 Install via your favorite package manager

--- a/doc/mesonist.txt
+++ b/doc/mesonist.txt
@@ -37,6 +37,14 @@ g:mesonist_meson_executable  Provide your own meson executable, if cannot be
 g:mesonist_meson_builddir    Set the name of the build directoy you want
                              to use.  Defaults to 'builddir'.
 
+                                                       *g:mesonist_c_compiler*
+g:mesonist_c_compiler       Set the C compiler to use during 'meson setup'.
+                            If not set default compiler will be used.
+
+                                                     *g:mesonist_cxx_compiler*
+g:mesonist_cxx_compiler     Set the CXX compiler to use during 'meson setup'.
+                            If not set default compiler will be used.
+
 
 ABOUT                                                         *mesonist-about*
 

--- a/plugin/mesonist.vim
+++ b/plugin/mesonist.vim
@@ -67,7 +67,15 @@ function! s:MesonistSetup() abort
     let l:old_dir = chdir(s:mesonist_meson_root_path)
   endif
 
-  let &makeprg = g:mesonist_meson_executable . ' setup ' . g:mesonist_meson_builddir
+  let l:environment_variables = []
+  if exists("g:mesonist_c_compiler")
+    let l:environment_variables += ["CC=" . g:mesonist_c_compiler]
+  endif
+  if exists("g:mesonist_cxx_compiler")
+    let l:environment_variables += ["CXX=" . g:mesonist_cxx_compiler]
+  endif
+
+  let &makeprg = join(l:environment_variables, " ") . " " . g:mesonist_meson_executable . ' setup ' . g:mesonist_meson_builddir
   silent make
 
   let l:builddir = s:fnameescape(s:mesonist_meson_root_path . '/' . g:mesonist_meson_builddir)

--- a/test/meson-compiler.vader
+++ b/test/meson-compiler.vader
@@ -1,0 +1,58 @@
+Before:
+  " change to the test directory
+  if isdirectory("test")
+    cd test
+  endif
+  if !exists("test_path")
+    let test_path = fnamemodify(getcwd(), ':p')
+  endif
+
+After:
+  call chdir(test_path)
+  let build_path = fnamemodify(getcwd() . '/meson-project/' . g:mesonist_meson_builddir, ':p')
+  call delete(build_path, 'rf')
+
+Execute(Default values):
+  AssertEqual g:mesonist_meson_builddir, 'builddir', 'g:mesonist_meson_builddir not set'
+
+Execute(Compile meson project with gcc):
+  let g:mesonist_c_compiler = "gcc"
+  let g:mesonist_cxx_compiler = "g++"
+
+  cd meson-project
+  e meson.build
+  MesonSetup
+
+  Assert filereadable("builddir/build.ninja"), 'no build.ninja'
+
+  enew
+  read builddir/meson-logs/meson-log.txt
+  " C++ compiler for the host machine: g++ (gcc 9.3.0 "g++ (Arch Linux 9.3.0-1) 9.3.0")
+  g!/C++ compiler for the host machine/d
+  %s/C++ compiler for the host machine: //
+  %s/ (.*$//
+
+Expect:
+  g++
+
+Execute(Compile meson project with clang):
+  let g:mesonist_c_compiler = "clang"
+  let g:mesonist_cxx_compiler = "clang++"
+
+  cd meson-project
+  e meson.build
+  MesonSetup
+
+  Assert filereadable("builddir/build.ninja"), 'no build.ninja'
+
+  enew
+  read builddir/meson-logs/meson-log.txt
+  " C++ compiler for the host machine: clang++ (clang 9.0.1 "clang version 9.0.1 ")
+  g!/C++ compiler for the host machine/d
+  %s/C++ compiler for the host machine: //
+  %s/ (.*$//
+
+Expect:
+  clang++
+
+# vim:sw=2:ts=2:ft=vim


### PR DESCRIPTION
Fixes #8 

Provide the possibility to set the C/C++ compiler with variables
g:mesonist_c_compiler resp. g:mesonist_cxx_compiler. These variables are
passed to command meson setup by setting the environment variables CC
and/or CXX.