### PR TITLE
Add options to set C/C++ linker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,4 @@ jobs:
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-build-file-error.vader' > /dev/null
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-compile-project.vader' > /dev/null
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-compiler.vader' > /dev/null
+            vim -Nu ./test/.vimrc -c 'Vader! test/meson-linker.vader' > /dev/null

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ vim-mesonist is a Vim plugin to make working with
  * `g:mesonist_cxx_compiler` sets the C++ compiler to use. Same as environment
  variable `CXX`.
 
+ * `g:mesonist_c_linker` sets the C linker to use. Same as environment
+ variable `CC_LD`.
+
+ * `g:mesonist_cxx_linker` sets the C++ linker to use. Same as environment
+ variable `CXX_LD`.
+
 ## Installation
 
 Install via your favorite package manager

--- a/doc/mesonist.txt
+++ b/doc/mesonist.txt
@@ -45,6 +45,14 @@ g:mesonist_c_compiler       Set the C compiler to use during 'meson setup'.
 g:mesonist_cxx_compiler     Set the CXX compiler to use during 'meson setup'.
                             If not set default compiler will be used.
 
+                                                         *g:mesonist_c_linker*
+g:mesonist_c_linker       Set the C linker to use during 'meson setup'.
+                          If not set default linker will be used.
+
+                                                       *g:mesonist_cxx_linker*
+g:mesonist_cxx_linker     Set the CXX linker to use during 'meson setup'.
+                          If not set default linker will be used.
+
 
 ABOUT                                                         *mesonist-about*
 

--- a/plugin/mesonist.vim
+++ b/plugin/mesonist.vim
@@ -74,6 +74,12 @@ function! s:MesonistSetup() abort
   if exists("g:mesonist_cxx_compiler")
     let l:environment_variables += ["CXX=" . g:mesonist_cxx_compiler]
   endif
+  if exists("g:mesonist_c_linker")
+    let l:environment_variables += ["CC_LD=" . g:mesonist_c_linker]
+  endif
+  if exists("g:mesonist_cxx_linker")
+    let l:environment_variables += ["CXX_LD=" . g:mesonist_cxx_linker]
+  endif
 
   let &makeprg = join(l:environment_variables, " ") . " " . g:mesonist_meson_executable . ' setup ' . g:mesonist_meson_builddir
   silent make

--- a/test/meson-linker.vader
+++ b/test/meson-linker.vader
@@ -1,0 +1,36 @@
+Before:
+  " change to the test directory
+  if isdirectory("test")
+    cd test
+  endif
+  if !exists("test_path")
+    let test_path = fnamemodify(getcwd(), ':p')
+  endif
+
+After:
+  call chdir(test_path)
+  let build_path = fnamemodify(getcwd() . '/meson-project/' . g:mesonist_meson_builddir, ':p')
+  call delete(build_path, 'rf')
+
+Execute(Compile meson project linker gold ):
+  let g:mesonist_c_linker = "gold"
+  let g:mesonist_cxx_linker = "gold"
+
+  cd meson-project
+  e meson.build
+  MesonSetup
+
+  Assert filereadable("builddir/build.ninja"), 'no build.ninja'
+
+  enew
+  read builddir/meson-logs/meson-log.txt
+  " Remove all all lines except the following one:
+  " Using 'CXX_LD' from environment with value: 'gold'
+  g!/Using 'CXX_LD' from environment with value: /d
+
+" Currently meson logs the line twice
+Expect:
+  Using 'CXX_LD' from environment with value: 'gold'
+  Using 'CXX_LD' from environment with value: 'gold'
+
+# vim:sw=2:ts=2:ft=vim


### PR DESCRIPTION
Fixes #9 

Provide the possibility to set C/C++ compiler with variables
g:mesonist_c_linker resp. g:mesonist_cxx_linker. These variables are
passed to the command 'meson setup' by setting the environment variables
CC_LD and/or CXX_LD.