### PR TITLE
Enable arguments with command MesonistSetup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,3 +26,4 @@ jobs:
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-compiler.vader' > /dev/null
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-linker.vader' > /dev/null
             vim -Nu ./test/.vimrc -c 'Vader! test/meson-env-vars.vader' > /dev/null
+            vim -Nu ./test/.vimrc -c 'Vader! test/meson-compile-arguments.vader' > /dev/null

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ vim-mesonist is a Vim plugin to make working with
 
 ### Commamds
 
- * `:MesonSetup`: Set up a meson project.
+ * `:MesonSetup`: Set up a meson project. Any arguments given to `:MesonSetup`
+ will directly passed on to the meson command.
 
  * `:MesonLocateRootDir`: Locates project root directory and echoes it.
 

--- a/doc/mesonist.txt
+++ b/doc/mesonist.txt
@@ -14,7 +14,7 @@ gateway to meson.
 COMMANDS                                                   *mesonist-commands*
 
                                                               *:MesonistSetup*
-:MesonistSetup               Locates the meson root path with an upwards
+:MesonistSetup {args}        Locates the meson root path with an upwards
                              search to find directory holding the meson.build
                              file with function project(...). Once found it
                              runs 'meson setup <buildir>' and modifies the

--- a/plugin/mesonist.vim
+++ b/plugin/mesonist.vim
@@ -57,7 +57,7 @@ function! s:MesonistRootPath() abort
 endfunction
 
 " Setup meson project
-function! s:MesonistSetup() abort
+function! s:MesonistSetup(...) abort
   if s:mesonist_meson_root_path == ""
     let s:mesonist_meson_root_path = s:MesonistRootPath()
   endif
@@ -84,7 +84,7 @@ function! s:MesonistSetup() abort
     let l:environment_variables += ["CXX_LD=" . g:mesonist_cxx_linker]
   endif
 
-  let &makeprg = join(l:environment_variables, " ") . " " . g:mesonist_meson_executable . ' setup ' . g:mesonist_meson_builddir
+  let &makeprg = join(l:environment_variables, " ") . " " . g:mesonist_meson_executable . ' setup ' . g:mesonist_meson_builddir . ' ' . join(a:000)
   silent make
 
   let l:builddir = s:fnameescape(s:mesonist_meson_root_path . '/' . g:mesonist_meson_builddir)
@@ -96,6 +96,6 @@ function! s:MesonistSetup() abort
 endfunction
 
 command! -nargs=0 -bar -bang MesonLocateRootDir echo s:MesonistRootPath()
-command! -nargs=0 -bar MesonSetup call s:MesonistSetup()|redraw!
+command! -nargs=? -bar MesonSetup call s:MesonistSetup(<f-args>)|redraw!
 
 " vim:set sw=2 ts=2:

--- a/test/meson-compile-arguments.vader
+++ b/test/meson-compile-arguments.vader
@@ -21,19 +21,19 @@ Execute(Set up project twice):
   Assert filereadable("builddir/test-compile"), 'test-compile not compiled'
   cclose
 
-  let g:mesonist_cxx_linker = "lld"
+  let g:mesonist_cxx_linker = "gold"
   MesonSetup --wipe
   silent make
 
   enew
   read builddir/meson-logs/meson-log.txt
   " Remove all all lines except the following one:
-  " Using 'CXX_LD' from environment with value: 'lld'
+  " Using 'CXX_LD' from environment with value: 'gold'
   g!/Using 'CXX_LD' from environment with value: /d
 
 " Currently meson logs the line twice
 Expect:
-  Using 'CXX_LD' from environment with value: 'lld'
-  Using 'CXX_LD' from environment with value: 'lld'
+  Using 'CXX_LD' from environment with value: 'gold'
+  Using 'CXX_LD' from environment with value: 'gold'
 
 # vim:sw=2:ts=2:ft=vim

--- a/test/meson-compile-arguments.vader
+++ b/test/meson-compile-arguments.vader
@@ -1,0 +1,39 @@
+Before:
+  " change to the test directory
+  if isdirectory("test")
+    cd test
+  endif
+  if !exists("test_path")
+    let test_path = fnamemodify(getcwd(), ':p')
+  endif
+
+After:
+  call chdir(test_path)
+  let build_path = fnamemodify(getcwd() . '/meson-project/' . g:mesonist_meson_builddir, ':p')
+  call delete(build_path, 'rf')
+
+Execute(Set up project twice):
+  cd meson-project
+
+  e meson.build
+  MesonSetup
+  silent make
+  Assert filereadable("builddir/test-compile"), 'test-compile not compiled'
+  cclose
+
+  let g:mesonist_cxx_linker = "lld"
+  MesonSetup --wipe
+  silent make
+
+  enew
+  read builddir/meson-logs/meson-log.txt
+  " Remove all all lines except the following one:
+  " Using 'CXX_LD' from environment with value: 'lld'
+  g!/Using 'CXX_LD' from environment with value: /d
+
+" Currently meson logs the line twice
+Expect:
+  Using 'CXX_LD' from environment with value: 'lld'
+  Using 'CXX_LD' from environment with value: 'lld'
+
+# vim:sw=2:ts=2:ft=vim


### PR DESCRIPTION
Arguments give to command `:MesonistSetup {args}` are passed directly to the
`meson setup` command.