### PR TITLE
Remove debugging from test case

### DIFF
--- a/test/meson-compile-project.vader
+++ b/test/meson-compile-project.vader
@@ -21,7 +21,6 @@ Execute(Default values):
 
 Execute(Setup meson project):
   cd meson-project
-  Log getcwd()
   e meson.build
   MesonSetup
 


### PR DESCRIPTION
Remove Log entry from test case 'meson-compile-project.vader': Remnant
from debugging session.